### PR TITLE
Add new landing page sections

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,14 @@
-import Header from '@/components/Header'
-import Hero from '@/components/Hero'
-import Features from '@/components/Features'
-import Testimonials from '@/components/Testimonials'
-import FAQ from '@/components/FAQ'
-import Footer from '@/components/Footer'
+import Header from "@/components/Header";
+import Hero from "@/components/Hero";
+import Features from "@/components/Features";
+import Services from "@/components/Services";
+import Steps from "@/components/Steps";
+import Technology from "@/components/Technology";
+import About from "@/components/About";
+import Testimonials from "@/components/Testimonials";
+import FAQ from "@/components/FAQ";
+import FinalCTA from "@/components/FinalCTA";
+import Footer from "@/components/Footer";
 
 export default function Home() {
   return (
@@ -12,10 +17,15 @@ export default function Home() {
       <main className="flex-1">
         <Hero />
         <Features />
+        <Services />
+        <Steps />
+        <Technology />
+        <About />
         <Testimonials />
         <FAQ />
+        <FinalCTA />
       </main>
       <Footer />
     </div>
-  )
+  );
 }

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -1,0 +1,19 @@
+import data from "@/data/site-content.json";
+
+export default function About() {
+  const { about } = data;
+
+  return (
+    <section id="quem_somos" className="py-20 bg-[#F3F3F3]">
+      <div className="container mx-auto px-6 flex flex-col md:flex-row items-center gap-12">
+        <div className="flex-1">
+          <img src={about.img} alt={about.h2} className="rounded-2xl shadow-2xl" />
+        </div>
+        <div className="flex-1">
+          <h2 className="text-3xl font-bold text-[#333333] mb-6">{about.h2}</h2>
+          <p className="text-[#333333] whitespace-pre-line">{about.text}</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/FinalCTA.tsx
+++ b/components/FinalCTA.tsx
@@ -1,0 +1,22 @@
+import data from "@/data/site-content.json";
+
+export default function FinalCTA() {
+  const { final_cta } = data;
+
+  return (
+    <section id="cta" className="py-20 bg-gradient-to-br from-[#535DDF] to-[#6a72ff] text-white text-center">
+      <div className="container mx-auto px-6 max-w-2xl">
+        <h2 className="text-3xl font-bold mb-4">{final_cta.h2}</h2>
+        <p className="mb-8">{final_cta.h3}</p>
+        <a
+          href={final_cta.cta_whatsapp}
+          target="_blank"
+          rel="noopener"
+          className="inline-block px-8 py-3 bg-[#FF6600] rounded-xl shadow-lg hover:brightness-110 transition font-semibold"
+        >
+          {final_cta.cta_label}
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -1,0 +1,34 @@
+import data from "@/data/site-content.json";
+
+export default function Services() {
+  const { services } = data;
+
+  return (
+    <section id="services" className="py-20 bg-white">
+      <div className="container mx-auto px-6 flex flex-col md:flex-row items-center gap-12">
+        {/* Texto */}
+        <div className="flex-1">
+          <h2 className="text-3xl font-bold text-[#333333] mb-6">{services.h2}</h2>
+          <ul className="space-y-4 mb-8 text-[#333333]">
+            {services.bullets.map((b, i) => (
+              <li key={i}>{b}</li>
+            ))}
+          </ul>
+          <a
+            href={services.cta_whatsapp}
+            target="_blank"
+            rel="noopener"
+            className="inline-block px-6 py-3 bg-[#FF6600] text-white rounded-xl shadow hover:brightness-110 transition font-semibold"
+          >
+            {services.cta_label}
+          </a>
+        </div>
+
+        {/* Imagem */}
+        <div className="flex-1">
+          <img src={services.img} alt="Terapia Quântica" className="rounded-2xl shadow-2xl" />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/Steps.tsx
+++ b/components/Steps.tsx
@@ -1,0 +1,32 @@
+import data from "@/data/site-content.json";
+
+export default function Steps() {
+  const { steps } = data;
+
+  return (
+    <section id="etapas" className="py-20 bg-[#F3F3F3]">
+      <div className="container mx-auto px-6">
+        <h2 className="text-3xl font-bold text-center text-[#333333] mb-12">{steps.h2}</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {steps.items.map((s, i) => (
+            <div key={i} className="bg-white rounded-2xl p-6 shadow">
+              <h3 className="text-xl font-semibold mb-2 text-[#333333]">{s.title}</h3>
+              <p className="text-[#333333]">{s.desc}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="text-center mt-12">
+          <a
+            href={steps.cta_whatsapp}
+            target="_blank"
+            rel="noopener"
+            className="inline-block px-6 py-3 bg-[#FF6600] text-white rounded-xl shadow hover:brightness-110 transition font-semibold"
+          >
+            {steps.cta_label}
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/Technology.tsx
+++ b/components/Technology.tsx
@@ -1,0 +1,34 @@
+import data from "@/data/site-content.json";
+
+export default function Technology() {
+  const { technology } = data;
+
+  return (
+    <section id="technology" className="py-20 bg-white">
+      <div className="container mx-auto px-6 flex flex-col md:flex-row items-center gap-12">
+        {/* Texto */}
+        <div className="flex-1">
+          <h2 className="text-3xl font-bold text-[#333333] mb-6">{technology.h2}</h2>
+          <ul className="space-y-4 mb-8 text-[#333333]">
+            {technology.bullets.map((b, i) => (
+              <li key={i}>{b}</li>
+            ))}
+          </ul>
+          <a
+            href={technology.cta_whatsapp}
+            target="_blank"
+            rel="noopener"
+            className="inline-block px-6 py-3 bg-[#FF6600] text-white rounded-xl shadow hover:brightness-110 transition font-semibold"
+          >
+            {technology.cta_label}
+          </a>
+        </div>
+
+        {/* Imagem */}
+        <div className="flex-1">
+          <img src={technology.img} alt="Tecnologia Quantec" className="rounded-2xl shadow-2xl" />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/data/site-content.json
+++ b/data/site-content.json
@@ -1,0 +1,46 @@
+{
+  "services": {
+    "h2": "Nossos Serviços de Medicina Quântica",
+    "bullets": [
+      "Tratamento à distância com uso do Quantec",
+      "Análise energética personalizada",
+      "Acompanhamento semanal dos resultados"
+    ],
+    "cta_whatsapp": "https://wa.me/5521979658483?text=Gostaria%20de%20iniciar%20o%20tratamento",
+    "cta_label": "Quero começar agora",
+    "img": "https://quantecportal.com/wp-content/uploads/2025/03/servicos.webp"
+  },
+  "steps": {
+    "h2": "Como funciona o processo",
+    "items": [
+      { "title": "1. Questionário Inicial", "desc": "Coletamos informações para personalizar o envio das frequências." },
+      { "title": "2. Envio da Foto", "desc": "Utilizamos sua foto para identificar seu campo energético." },
+      { "title": "3. Programação do Equipamento", "desc": "Configuramos o Quantec com as frequências adequadas." },
+      { "title": "4. Acompanhamento", "desc": "Você recebe feedbacks periódicos dos resultados alcançados." }
+    ],
+    "cta_whatsapp": "https://wa.me/5521979658483?text=Quero%20saber%20mais%20sobre%20as%20etapas",
+    "cta_label": "Falar com Especialista"
+  },
+  "technology": {
+    "h2": "Tecnologia Quantec Exclusiva",
+    "bullets": [
+      "Envio de frequências à distância",
+      "Resultados mensuráveis",
+      "Equipamento certificado na Europa"
+    ],
+    "cta_whatsapp": "https://wa.me/5521979658483?text=Quero%20conhecer%20a%20tecnologia",
+    "cta_label": "Conhecer a Tecnologia",
+    "img": "https://quantecportal.com/wp-content/uploads/2025/03/tecnologia.webp"
+  },
+  "about": {
+    "h2": "Quem Somos",
+    "img": "https://quantecportal.com/wp-content/uploads/2025/03/sobre.webp",
+    "text": "Somos especialistas em terapia quântica, com anos de experiência utilizando o Quantec para melhorar a vida de centenas de pessoas."
+  },
+  "final_cta": {
+    "h2": "Transforme sua Energia",
+    "h3": "Inicie hoje mesmo sua jornada de equilíbrio com a nossa equipe",
+    "cta_whatsapp": "https://wa.me/5521979658483?text=Gostaria%20de%20agendar",
+    "cta_label": "Agendar Sessão"
+  }
+}


### PR DESCRIPTION
## Summary
- add content configuration in `data/site-content.json`
- add Services, Steps, Technology, About and FinalCTA components
- update home page to include new sections

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b4da4c2083299a1c765c046a2d4b