### PR TITLE
Fix Steps component fields

### DIFF
--- a/components/Steps.tsx
+++ b/components/Steps.tsx
@@ -7,14 +7,16 @@ export default function Steps() {
     <section id="etapas" className="py-20 bg-[#F3F3F3]">
       <div className="container mx-auto px-6">
         <h2 className="text-3xl font-bold text-center text-[#333333] mb-12">{steps.h2}</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          {steps.items.map((s, i) => (
-            <div key={i} className="bg-white rounded-2xl p-6 shadow">
-              <h3 className="text-xl font-semibold mb-2 text-[#333333]">{s.title}</h3>
-              <p className="text-[#333333]">{s.desc}</p>
-            </div>
-          ))}
-        </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+            {steps.items.map((s, i) => (
+              <div key={i} className="bg-white rounded-2xl p-6 shadow">
+                <h3 className="text-xl font-semibold mb-2 text-[#333333]">
+                  {s.h3}
+                </h3>
+                <p className="text-[#333333]">{s.p}</p>
+              </div>
+            ))}
+          </div>
 
         <div className="text-center mt-12">
           <a


### PR DESCRIPTION
## Summary
- read `steps` data from `site-content.json`
- show correct heading and paragraph fields in `Steps` component

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d1f35dcc83298aae827102996055